### PR TITLE
[Resolver] 접속중인 회원 정보를 받는 Resolver 구현

### DIFF
--- a/src/main/java/com/optional/formula/common/config/WebConfig.java
+++ b/src/main/java/com/optional/formula/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.optional.formula.common.config;
+
+import com.optional.formula.common.resolver.CurrentUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
@@ -2,6 +2,7 @@ package com.optional.formula.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -9,7 +10,9 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR("COMMON-500", "서버 내부 오류입니다."),
     INVALID_INPUT_VALUE("COMMON-400", "잘못된 입력입니다."),
     METHOD_NOT_ALLOWED("COMMON-405", "허용되지 않은 HTTP 메서드입니다."),
-    ENTITY_NOT_FOUND("COMMON-404", "해당 리소스를 찾을 수 없습니다.");
+    ENTITY_NOT_FOUND("COMMON-404", "해당 리소스를 찾을 수 없습니다."),
+    UNAUTHORIZED("COMMON-401", "인가 받지 않았습니다. 로그인이 필요합니다.");
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/optional/formula/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/optional/formula/common/exception/GlobalExceptionHandler.java
@@ -17,9 +17,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> businessExceptionHandler(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("Business Exception: [{}] {}", errorCode.getCode(), errorCode.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(errorCode));
+
+        HttpStatus status = switch (errorCode) {
+            case CommonErrorCode.UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+            case CommonErrorCode.ENTITY_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case CommonErrorCode.METHOD_NOT_ALLOWED -> HttpStatus.METHOD_NOT_ALLOWED;
+            default -> HttpStatus.BAD_REQUEST;
+        };
+
+        return ResponseEntity.status(status).body(ErrorResponse.of(errorCode));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/optional/formula/common/resolver/CurrentUser.java
+++ b/src/main/java/com/optional/formula/common/resolver/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.optional.formula.common.resolver;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser { }

--- a/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
@@ -3,6 +3,7 @@ package com.optional.formula.common.resolver;
 import com.optional.formula.common.exception.BusinessException;
 import com.optional.formula.common.exception.CommonErrorCode;
 import com.optional.formula.user.domain.entity.UserRole;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -31,20 +32,20 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         String userId = webRequest.getHeader(USER_ID);
         String userRole = webRequest.getHeader(USER_ROLE);
         
-        if (userId == null || userRole == null) {
+        if (userId == null || userId.isBlank() || userRole == null || userRole.isBlank()) {
             throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
         }
 
         try {
-            long id = Long.parseLong(userId);
+            long id = Long.parseLong(userId.trim());
 
             if (id <= 0) {
                 throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
             }
 
-            UserRole role = UserRole.valueOf(userRole);
+            UserRole role = UserRole.valueOf(userRole.trim().toUpperCase(Locale.ROOT));
             return CurrentUserInfo.of(id, role);
-        } catch (NumberFormatException e) {
+        } catch (IllegalArgumentException e) {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
         }
     }

--- a/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.optional.formula.common.resolver;
+
+import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.exception.CommonErrorCode;
+import com.optional.formula.user.domain.entity.UserRole;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j(topic = "CurrentUserArgumentResolver")
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String USER_ID = "X-USER-ID";
+    private static final String USER_ROLE = "X-USER-ROLE";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(CurrentUserInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        String userId = webRequest.getHeader(USER_ID);
+        String userRole = webRequest.getHeader(USER_ROLE);
+        
+        if (userId == null || userRole == null) {
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            long id = Long.parseLong(userId);
+
+            if (id <= 0) {
+                throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
+            }
+
+            UserRole role = UserRole.valueOf(userRole);
+            return CurrentUserInfo.of(id, role);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(CommonErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}

--- a/src/main/java/com/optional/formula/common/resolver/CurrentUserInfo.java
+++ b/src/main/java/com/optional/formula/common/resolver/CurrentUserInfo.java
@@ -1,0 +1,13 @@
+package com.optional.formula.common.resolver;
+
+import com.optional.formula.user.domain.entity.UserRole;
+
+public record CurrentUserInfo(
+        Long userId,
+        UserRole userRole
+) {
+
+    public static CurrentUserInfo of(Long userId, UserRole userRole) {
+        return new CurrentUserInfo(userId, userRole);
+    }
+}


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 현재 접속중인 회원 id와 role을 요청 헤더로부터 자동 주입받는 CurrentUser 애너테이션 구현

## 🔍 관련 이슈
- Closes #25

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 요청 헤더(X-USER-ID, X-USER-ROLE)를 기반으로 컨트롤러에 현재 사용자 정보를 자동 주입해 인증 처리를 간소화했습니다.
  * 컨트롤러에서 현재 사용자 식별 및 역할 기반 처리를 바로 활용할 수 있습니다.
* 개선
  * 인증 관련 예외 처리에서 에러 코드에 따라 적절한 HTTP 상태(예: 401, 404, 405 등)를 반환하도록 개선했습니다.
  * 유효하지 않은 사용자 ID/역할 입력에 대한 검증을 추가해 즉시 오류를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->