### PR TITLE
[AOP] 회원 권한을 확인하는 AOP 구현

### DIFF
--- a/src/main/java/com/optional/formula/common/aop/PreAuthorizeUser.java
+++ b/src/main/java/com/optional/formula/common/aop/PreAuthorizeUser.java
@@ -1,0 +1,17 @@
+package com.optional.formula.common.aop;
+
+import com.optional.formula.user.domain.entity.UserRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PreAuthorizeUser {
+    UserRole[] userRole() default {
+            UserRole.ADMIN,
+            UserRole.MANAGER,
+            UserRole.USER
+    };
+}

--- a/src/main/java/com/optional/formula/common/aop/PreAuthorizeUserAspect.java
+++ b/src/main/java/com/optional/formula/common/aop/PreAuthorizeUserAspect.java
@@ -1,0 +1,58 @@
+package com.optional.formula.common.aop;
+
+import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.user.domain.entity.UserRole;
+import com.optional.formula.user.exception.UserErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Locale;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j(topic = "PreAuthorizeUserAspect")
+@Aspect
+@Component
+public class PreAuthorizeUserAspect {
+
+    private static final String USER_ROLE = "X-USER-ROLE";
+
+    @Before("@annotation(preAuthorizeUser)")
+    public void preAuthorize(JoinPoint joinPoint, PreAuthorizeUser preAuthorizeUser) {
+        Set<UserRole> allowedUserRole = Set.of(preAuthorizeUser.userRole());
+        UserRole currentUserRole = getCurrentUserRole();
+
+        if (!allowedUserRole.contains(currentUserRole)) {
+            log.info("접근 권한 없음: 현재 역할={}, 허용 역할={}", currentUserRole, allowedUserRole);
+            throw new BusinessException(UserErrorCode.INVALID_HEADER);
+        }
+    }
+
+    private UserRole getCurrentUserRole() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        if (attributes == null) {
+            log.info("ServletRequestAttributes 가 NULL 입니다.");
+            throw new BusinessException(UserErrorCode.INVALID_HEADER);
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        String userRole = request.getHeader(USER_ROLE);
+
+        if (userRole == null || userRole.isEmpty()) {
+            log.info("User-Role 이 비어 있습니다.");
+            throw new BusinessException(UserErrorCode.INVALID_HEADER);
+        }
+
+        try {
+            return UserRole.valueOf(userRole.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            log.info("유효하지 않는 User-Role: {}", userRole);
+            throw new BusinessException(UserErrorCode.INVALID_HEADER);
+        }
+    }
+}

--- a/src/main/java/com/optional/formula/common/config/FilterConfig.java
+++ b/src/main/java/com/optional/formula/common/config/FilterConfig.java
@@ -1,0 +1,35 @@
+package com.optional.formula.common.config;
+
+import com.optional.formula.common.filter.JwtAuthenticationFilter;
+import com.optional.formula.common.filter.JwtFilterProperties;
+import com.optional.formula.common.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+    private final JwtProvider jwtProvider;
+    private final JwtFilterProperties jwtFilterProperties;
+
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtProvider, jwtFilterProperties);
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter() {
+        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
+
+        registrationBean.setFilter(jwtAuthenticationFilter());
+
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(1);
+
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
@@ -7,13 +7,19 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-    INTERNAL_SERVER_ERROR("COMMON-500", "서버 내부 오류입니다."),
-    INVALID_INPUT_VALUE("COMMON-400", "잘못된 입력입니다."),
-    METHOD_NOT_ALLOWED("COMMON-405", "허용되지 않은 HTTP 메서드입니다."),
-    ENTITY_NOT_FOUND("COMMON-404", "해당 리소스를 찾을 수 없습니다."),
-    UNAUTHORIZED("COMMON-401", "인가 받지 않았습니다. 로그인이 필요합니다.");
 
+    INTERNAL_SERVER_ERROR("COMMON-500", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_INPUT_VALUE("COMMON-400", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
+    METHOD_NOT_ALLOWED("COMMON-405", "허용되지 않은 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    ENTITY_NOT_FOUND("COMMON-404", "해당 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("COMMON-401", "인가 받지 않았습니다. 로그인이 필요합니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public int getStatus() {
+        return status.value();
+    }
 }

--- a/src/main/java/com/optional/formula/common/exception/ErrorCode.java
+++ b/src/main/java/com/optional/formula/common/exception/ErrorCode.java
@@ -6,4 +6,6 @@ public interface ErrorCode {
     String getCode();
 
     String getMessage();
+
+    int getStatus(); 
 }

--- a/src/main/java/com/optional/formula/common/exception/ErrorResponse.java
+++ b/src/main/java/com/optional/formula/common/exception/ErrorResponse.java
@@ -5,30 +5,26 @@ import java.util.List;
 public record ErrorResponse(
         String code,
         String message,
+        int status,
         List<ValidationError> errors
 ) {
 
     public static ErrorResponse of(ErrorCode errorCode, List<ValidationError> errors) {
-        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors);
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errorCode.getStatus(), errors);
     }
 
     public static ErrorResponse of(ErrorCode errorCode, Exception error) {
-        ValidationError validationError = new ValidationError(errorCode.getCode(),
-                errorCode.getMessage());
-
-        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                List.of(validationError));
+        ValidationError validationError = new ValidationError(errorCode.getCode(), errorCode.getMessage());
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errorCode.getStatus(), List.of(validationError));
     }
 
     public static ErrorResponse of(ErrorCode errorCode) {
-        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errorCode.getStatus(), null);
     }
 
     public record ValidationError(String field, String reason) {
-
         public static ValidationError of(String field, String reason) {
             return new ValidationError(field, reason);
         }
     }
 }
-

--- a/src/main/java/com/optional/formula/common/filter/ExceptionHandlingFilter.java
+++ b/src/main/java/com/optional/formula/common/filter/ExceptionHandlingFilter.java
@@ -1,0 +1,48 @@
+package com.optional.formula.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.exception.CommonErrorCode;
+import com.optional.formula.common.exception.ErrorCode;
+import com.optional.formula.common.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Component
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (BusinessException e) {
+            setErrorResponse(response, e.getErrorCode());
+        } catch (Exception e) {
+            setErrorResponse(response, CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+            throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+
+        response.setStatus(errorCode.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/optional/formula/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/optional/formula/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.optional.formula.common.filter;
+
+import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.jwt.JwtProvider;
+import com.optional.formula.user.domain.entity.UserRole;
+import com.optional.formula.user.exception.UserErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final JwtFilterProperties filterProperties;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+
+        return filterProperties.getExcludePaths().stream()
+                .anyMatch(pattern -> requestURI.matches(convertAntToRegex(pattern)));
+    }
+
+    @Override
+    public void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String bearerToken = request.getHeader("Authorization");
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+
+            try {
+                Long userId = jwtProvider.getUserId(token);
+                String userRoleStr = jwtProvider.getUserRole(token);
+
+                UserRole userRole = UserRole.valueOf(userRoleStr.toUpperCase());
+
+                request.setAttribute("X_USER_ID", userId);
+                request.setAttribute("X_USER_ROLE", userRole);
+
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(UserErrorCode.INVALID_ROLE_VALUE);
+            } catch (BusinessException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new BusinessException(UserErrorCode.INVALID_TOKEN);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String convertAntToRegex(String antPattern) {
+        return antPattern.replace("**", ".*").replace("*", "[^/]*");
+    }
+}

--- a/src/main/java/com/optional/formula/common/filter/JwtFilterProperties.java
+++ b/src/main/java/com/optional/formula/common/filter/JwtFilterProperties.java
@@ -1,0 +1,16 @@
+package com.optional.formula.common.filter;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.jwt.filter")
+public class JwtFilterProperties {
+    private List<String> includePaths;
+    private List<String> excludePaths;
+}

--- a/src/main/java/com/optional/formula/common/jwt/JwtErrorCode.java
+++ b/src/main/java/com/optional/formula/common/jwt/JwtErrorCode.java
@@ -3,16 +3,24 @@ package com.optional.formula.common.jwt;
 import com.optional.formula.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 @Getter
 public enum JwtErrorCode implements ErrorCode {
-    EXPIRED_TOKEN("JWT-001", "만료된 토큰입니다."),
-    MALFORMED_TOKEN("JWT-002", "JWT 형식이 잘못되었습니다."),
-    TAMPERED_TOKEN("JWT-003", "JWT 서명이 위조되었거나 무결성이 손상되었습니다."),
-    NOT_FOUND_TOKEN("JWT-004", "토큰을 찾을 수 없습니다."),
-    INVALID_BEARER_TOKEN("JWT-005", "유효하지 않은 토큰입니다.");
+
+    EXPIRED_TOKEN("JWT-001", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    MALFORMED_TOKEN("JWT-002", "JWT 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+    TAMPERED_TOKEN("JWT-003", "JWT 서명이 위조되었거나 무결성이 손상되었습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_FOUND_TOKEN("JWT-004", "토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_BEARER_TOKEN("JWT-005", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public int getStatus() {
+        return status.value();
+    }
 }

--- a/src/main/java/com/optional/formula/common/jwt/JwtProvider.java
+++ b/src/main/java/com/optional/formula/common/jwt/JwtProvider.java
@@ -75,7 +75,7 @@ public class JwtProvider {
         return claims.getExpiration().getTime() - System.currentTimeMillis();
     }
 
-    public String getRole(String token) {
+    public String getUserRole(String token) {
         Claims claims = extractClaims(token);
         return claims.get("USER_ROLE").toString();
     }

--- a/src/main/java/com/optional/formula/user/application/service/AuthService.java
+++ b/src/main/java/com/optional/formula/user/application/service/AuthService.java
@@ -165,7 +165,7 @@ public class AuthService implements AuthUseCase {
         verifyRefreshToken(request.refreshToken());
 
         Long userId = jwtProvider.getUserId(accessToken);
-        String role = jwtProvider.getRole(accessToken);
+        String role = jwtProvider.getUserRole(accessToken);
 
         String savedRT = refreshTokenRepository.getRefreshToken(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.INVALID_TOKEN));

--- a/src/main/java/com/optional/formula/user/exception/UserErrorCode.java
+++ b/src/main/java/com/optional/formula/user/exception/UserErrorCode.java
@@ -17,7 +17,9 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_CODE("USER-006", "회원: 유효하지 않은 코드 번호입니다."),
     MALFORMED_CODE("USER-007", "회원: 이메일 코드 번호는 6자리입니다."),
 
-    EMAIL_SEND_FAIL("USER-008", "회원: 이메일 전송에 실패했습니다.");
+    EMAIL_SEND_FAIL("USER-008", "회원: 이메일 전송에 실패했습니다."),
+    INVALID_HEADER("USER-009", "회원: 유효하지 않은 헤더 정보입니다.");
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/optional/formula/user/exception/UserErrorCode.java
+++ b/src/main/java/com/optional/formula/user/exception/UserErrorCode.java
@@ -3,24 +3,31 @@ package com.optional.formula.user.exception;
 import com.optional.formula.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 @Getter
 public enum UserErrorCode implements ErrorCode {
 
-    USER_DUPLICATED("USER-001", "회원: 이미 존재하는 사용자입니다."),
-    USER_EMAIL_DUPLICATED("USER-002", "회원: 이미 존재하는 이메일입니다."),
-    USER_PASSWORD_INVALID("USER-003", "회원: 잘못된 비밀번호입니다."),
-    USER_NOT_FOUND("USER-004", "회원: 사용자를 찾을 수 없습니다."),
+    USER_DUPLICATED("USER-001", "회원: 이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
+    USER_EMAIL_DUPLICATED("USER-002", "회원: 이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
+    USER_PASSWORD_INVALID("USER-003", "회원: 잘못된 비밀번호입니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("USER-004", "회원: 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
-    INVALID_TOKEN("USER-005", "회원: 유효하지 않은 토큰입니다."),
-    INVALID_CODE("USER-006", "회원: 유효하지 않은 코드 번호입니다."),
-    MALFORMED_CODE("USER-007", "회원: 이메일 코드 번호는 6자리입니다."),
+    INVALID_TOKEN("USER-005", "회원: 유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_CODE("USER-006", "회원: 유효하지 않은 코드 번호입니다.", HttpStatus.BAD_REQUEST),
+    MALFORMED_CODE("USER-007", "회원: 이메일 코드 번호는 6자리입니다.", HttpStatus.BAD_REQUEST),
 
-    EMAIL_SEND_FAIL("USER-008", "회원: 이메일 전송에 실패했습니다."),
-    INVALID_HEADER("USER-009", "회원: 유효하지 않은 헤더 정보입니다.");
-
+    EMAIL_SEND_FAIL("USER-008", "회원: 이메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_HEADER("USER-009", "회원: 유효하지 않은 헤더 정보입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ROLE_VALUE("USER-010", "회원: 유효하지 않은 권한입니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public int getStatus() {
+        return status.value();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,12 @@ spring:
     secret: ${SECRET}
     access-token-expiration: ${ACCESS-TOKEN-EXPIRATION}
     refresh-token-expiration: ${REFRESH-TOKEN-EXPIRATION}
+    filter:
+      include-paths:
+        - /api/**
+      exclude-paths:
+        - /api/users/**
+
 
   mail:
     host: smtp.naver.com

--- a/src/test/java/com/optional/formula/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/optional/formula/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,106 @@
+package com.optional.formula.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.filter.JwtAuthenticationFilter;
+import com.optional.formula.common.filter.JwtFilterProperties;
+import com.optional.formula.common.jwt.JwtProvider;
+import com.optional.formula.user.domain.entity.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private JwtFilterProperties jwtFilterProperties;
+
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        jwtFilterProperties = new JwtFilterProperties();
+        jwtFilterProperties.setIncludePaths(List.of("/api/**"));
+        jwtFilterProperties.setExcludePaths(List.of("/api/public/**"));
+
+        jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider, jwtFilterProperties);
+    }
+
+    @Test
+    @DisplayName("제외 경로에 해당하는 요청은 필터링하지 않는다 (shouldNotFilter)")
+    void shouldNotFilter_whenRequestUriIsExcluded() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/public/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when & then
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // 필터를 통과해서 아무 일 없이 다음 필터로 넘어간다
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰일 경우 사용자 ID 및 권한 정보를 Request에 설정한다")
+    void shouldFilter_andSetUserAttributes_whenValidToken()
+            throws ServletException, IOException, IOException {
+        // given
+        String token = "valid.jwt.token";
+        Long userId = 1L;
+        String userRole = "USER";
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
+        request.addHeader("Authorization", "Bearer " + token);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.getUserId(token)).thenReturn(userId);
+        when(jwtProvider.getUserRole(token)).thenReturn(userRole);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        assertThat(request.getAttribute("X_USER_ID")).isEqualTo(userId);
+        assertThat(request.getAttribute("X_USER_ROLE")).isEqualTo(UserRole.USER);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰일 경우 BusinessException 예외를 던진다")
+    void shouldThrowBusinessException_whenInvalidToken() {
+        // given
+        String token = "invalid.token";
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.getUserId(token)).thenThrow(new RuntimeException("유효하지 않은 토큰"));
+
+        // then
+        assertThatThrownBy(
+                () -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/optional/formula/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/optional/formula/user/application/service/AuthServiceTest.java
@@ -175,7 +175,7 @@ class AuthServiceTest {
         long remainingTime = 3600000L; // 1시간
 
         given(jwtProvider.getUserId(accessToken)).willReturn(userId);
-        given(jwtProvider.getRole(accessToken)).willReturn("USER");
+        given(jwtProvider.getUserRole(accessToken)).willReturn("USER");
         given(refreshTokenRepository.getRefreshToken(userId)).willReturn(Optional.of(savedRefreshToken));
         given(jwtProvider.getRemainingTime(savedRefreshToken)).willReturn(remainingTime);
         given(jwtProvider.generateAccessToken(userId, testUser.getUserRole())).willReturn(newAccessToken);
@@ -192,7 +192,7 @@ class AuthServiceTest {
 
         // verify
         verify(jwtProvider).getUserId(accessToken);
-        verify(jwtProvider).getRole(accessToken);
+        verify(jwtProvider).getUserRole(accessToken);
         verify(refreshTokenRepository).getRefreshToken(userId);
         verify(jwtProvider).getRemainingTime(savedRefreshToken);
         verify(refreshTokenRepository).setTokenBlacklist(userId, remainingTime);
@@ -229,7 +229,7 @@ class AuthServiceTest {
         ReissueTokenRequest wrongRequest = new ReissueTokenRequest(wrongRefreshToken);
 
         given(jwtProvider.getUserId(accessToken)).willReturn(userId);
-        given(jwtProvider.getRole(accessToken)).willReturn("USER");
+        given(jwtProvider.getUserRole(accessToken)).willReturn("USER");
         given(refreshTokenRepository.getRefreshToken(userId)).willReturn(Optional.of(refreshToken));
 
         // when & then
@@ -247,7 +247,7 @@ class AuthServiceTest {
     void reissueToken_fail_when_rt_not_found() {
         // given
         given(jwtProvider.getUserId(accessToken)).willReturn(userId);
-        given(jwtProvider.getRole(accessToken)).willReturn("USER");
+        given(jwtProvider.getUserRole(accessToken)).willReturn("USER");
         given(refreshTokenRepository.getRefreshToken(userId)).willReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- AOP 기반의 회원 권한을 메서드 레벨에서 권한 검사하는 애너테이션을 구현

## 🔍 관련 이슈
- Closes #27

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 메서드 수준의 역할 기반 접근 제어 추가(허용된 역할만 접근 가능).
  * JWT 기반 인증 필터 및 예외 처리 필터가 도입되어 요청 흐름에서 인증/오류를 일관되게 처리.
  * 오류 응답에 HTTP 상태 코드가 포함되도록 오류 코드/응답 형식 확장.
  * JWT 필터 경로 설정을 위한 구성 옵션 추가.
* **테스트**
  * JWT 인증 필터 동작을 검증하는 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->