### PR TITLE
[Filter] JWT 인증 필터와 접속중인 회원 정보 리졸버를 개선

### DIFF
--- a/src/main/java/com/optional/formula/common/config/FilterConfig.java
+++ b/src/main/java/com/optional/formula/common/config/FilterConfig.java
@@ -3,33 +3,25 @@ package com.optional.formula.common.config;
 import com.optional.formula.common.filter.JwtAuthenticationFilter;
 import com.optional.formula.common.filter.JwtFilterProperties;
 import com.optional.formula.common.jwt.JwtProvider;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RequiredArgsConstructor
 public class FilterConfig {
 
-    private final JwtProvider jwtProvider;
-    private final JwtFilterProperties jwtFilterProperties;
-
-
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtProvider, jwtFilterProperties);
-    }
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter(
+            JwtProvider jwtProvider,
+            JwtFilterProperties props
+    ) {
+        JwtAuthenticationFilter filter =
+                new JwtAuthenticationFilter(jwtProvider, props.getExcludePaths());
 
-    @Bean
-    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter() {
-        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
-
-        registrationBean.setFilter(jwtAuthenticationFilter());
-
-        registrationBean.addUrlPatterns("/*");
-        registrationBean.setOrder(1);
-
-        return registrationBean;
+        FilterRegistrationBean<JwtAuthenticationFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(filter);
+        reg.addUrlPatterns("/*");
+        reg.setOrder(1);
+        return reg;
     }
 }

--- a/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/optional/formula/common/exception/CommonErrorCode.java
@@ -12,7 +12,10 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_INPUT_VALUE("COMMON-400", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
     METHOD_NOT_ALLOWED("COMMON-405", "허용되지 않은 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
     ENTITY_NOT_FOUND("COMMON-404", "해당 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    UNAUTHORIZED("COMMON-401", "인가 받지 않았습니다. 로그인이 필요합니다.", HttpStatus.UNAUTHORIZED);
+    UNAUTHORIZED("COMMON-401", "인가 받지 않았습니다. 로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_HEADER("COMMON-401", "Authorization 헤더가 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("COMMON-400", "Bearer {token} 형식이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ROLE_BY_TOKEN("COMMON-400", "토큰 안에 유효하지 않은 권한이 포함되어 있습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/optional/formula/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/optional/formula/common/filter/JwtAuthenticationFilter.java
@@ -1,29 +1,65 @@
 package com.optional.formula.common.filter;
 
 import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.exception.CommonErrorCode;
 import com.optional.formula.common.jwt.JwtProvider;
 import com.optional.formula.user.domain.entity.UserRole;
-import com.optional.formula.user.exception.UserErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.PathContainer;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
-@RequiredArgsConstructor
+@Slf4j(topic = "JwtAuthenticationFilter")
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final JwtFilterProperties filterProperties;
+    private final List<PathPattern> excludePatterns;
+    private final PathPatternParser parser = PathPatternParser.defaultInstance;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, List<String> excludePaths) {
+        this.jwtProvider = jwtProvider;
+        this.excludePatterns = compilePatterns(excludePaths);
+    }
+
+    private List<PathPattern> compilePatterns(List<String> raw) {
+        return raw.stream()
+                .flatMap(p -> {
+                    // 1) 원본 패턴
+                    Stream<String> s = Stream.of(p);
+                    // 2) "/**"로 끝나면 기저 경로도 추가 (예: "/api/public/**" -> "/api/public")
+                    if (p.endsWith("/**")) {
+                        s = Stream.concat(s, Stream.of(p.substring(0, p.length() - 3)));
+                    }
+                    // 3) 트레일링 "/"로 끝나면 슬래시 제거 버전도 추가 (예: "/docs/" -> "/docs")
+                    if (p.endsWith("/") && p.length() > 1) {
+                        s = Stream.concat(s, Stream.of(p.substring(0, p.length() - 1)));
+                    }
+                    return s.distinct();
+                })
+                .map(parser::parse)
+                .toList();
+    }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String requestURI = request.getRequestURI();
+        String path = stripContextPath(request.getRequestURI(), request.getContextPath());
+        PathContainer container = PathContainer.parsePath(path);
+        return excludePatterns.stream().anyMatch(p -> p.matches(container));
+    }
 
-        return filterProperties.getExcludePaths().stream()
-                .anyMatch(pattern -> requestURI.matches(convertAntToRegex(pattern)));
+    private String stripContextPath(String uri, String ctx) {
+        return (ctx != null && !ctx.isEmpty() && uri.startsWith(ctx)) ? uri.substring(ctx.length())
+                : uri;
     }
 
     @Override
@@ -32,32 +68,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
 
-        String bearerToken = request.getHeader("Authorization");
+        if (!shouldNotFilter(request)) {
+            String tokenByHeader = request.getHeader("Authorization");
 
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            String token = bearerToken.substring(7);
+            if (tokenByHeader == null || tokenByHeader.isEmpty()) {
+                throw new BusinessException(CommonErrorCode.INVALID_HEADER);
+            }
+
+            if (!tokenByHeader.startsWith("Bearer ")) {
+                throw new BusinessException(CommonErrorCode.INVALID_TOKEN);
+            }
+
+            String accessToken = tokenByHeader.substring(7);
 
             try {
-                Long userId = jwtProvider.getUserId(token);
-                String userRoleStr = jwtProvider.getUserRole(token);
-
-                UserRole userRole = UserRole.valueOf(userRoleStr.toUpperCase());
-
+                Long userId = jwtProvider.getUserId(accessToken);
+                UserRole userRole = UserRole.valueOf(
+                        jwtProvider.getUserRole(accessToken).toUpperCase());
                 request.setAttribute("X_USER_ID", userId);
                 request.setAttribute("X_USER_ROLE", userRole);
 
             } catch (IllegalArgumentException e) {
-                throw new BusinessException(UserErrorCode.INVALID_ROLE_VALUE);
+                throw new BusinessException(CommonErrorCode.INVALID_ROLE_BY_TOKEN);
             } catch (BusinessException e) {
                 throw e;
             } catch (Exception e) {
-                throw new BusinessException(UserErrorCode.INVALID_TOKEN);
+                throw new BusinessException(CommonErrorCode.INVALID_TOKEN);
             }
         }
         filterChain.doFilter(request, response);
     }
 
-    private String convertAntToRegex(String antPattern) {
-        return antPattern.replace("**", ".*").replace("*", "[^/]*");
-    }
 }

--- a/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/optional/formula/common/resolver/CurrentUserArgumentResolver.java
@@ -4,7 +4,6 @@ import com.optional.formula.common.exception.BusinessException;
 import com.optional.formula.common.exception.CommonErrorCode;
 import com.optional.formula.user.domain.entity.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -16,9 +15,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Slf4j(topic = "CurrentUserArgumentResolver")
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private static final String USER_ID = "X-USER-ID";
-    private static final String USER_ROLE = "X-USER-ROLE";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
       include-paths:
         - /api/**
       exclude-paths:
-        - /api/users/**
+        - /api/v1/auth/**
 
 
   mail:
@@ -62,3 +62,8 @@ spring:
           timeout: ${TIMEOUT}
           writeTimeout: ${TIMEOUT}
         debug: true
+
+logging:
+  level:
+    com.optional.formula.common.filter.JwtAuthenticationFilter: DEBUG
+    com.optional.formula.common.resolver.CurrentUserArgumentResolver: DEBUG

--- a/src/test/java/com/optional/formula/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/optional/formula/filter/JwtAuthenticationFilterTest.java
@@ -4,21 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.optional.formula.common.exception.BusinessException;
+import com.optional.formula.common.exception.CommonErrorCode;
 import com.optional.formula.common.filter.JwtAuthenticationFilter;
 import com.optional.formula.common.filter.JwtFilterProperties;
 import com.optional.formula.common.jwt.JwtProvider;
 import com.optional.formula.user.domain.entity.UserRole;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -29,111 +32,334 @@ class JwtAuthenticationFilterTest {
 
     @Mock
     private JwtProvider jwtProvider;
-
     @Mock
     private FilterChain filterChain;
 
-    private JwtFilterProperties jwtFilterProperties;
-
-    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    private JwtFilterProperties props;
+    private JwtAuthenticationFilter filter;
 
     @BeforeEach
     void setUp() {
-        jwtFilterProperties = new JwtFilterProperties();
-        jwtFilterProperties.setIncludePaths(List.of("/api/**"));
-        jwtFilterProperties.setExcludePaths(List.of("/api/public/**"));
+        props = new JwtFilterProperties();
+        props.setIncludePaths(List.of("/api/**"));        // 현재는 사용 안 함
+        props.setExcludePaths(List.of("/api/public/**")); // 공개 경로
 
-        jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider, jwtFilterProperties);
+        // 변경: props 전체가 아니라 excludePaths만 전달
+        filter = new JwtAuthenticationFilter(jwtProvider, props.getExcludePaths());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/public/test", "/api/public/", "/api/public"})
+    @DisplayName("excludePaths(/api/public/**) : 해당 경로는 인증 우회(필터 로직 스킵)")
+    void bypass_forExcludedPublicPaths(String uri) throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", uri);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        // doFilter()를 호출해야 shouldNotFilter 로직이 반영됩니다.
+        filter.doFilter(req, res, filterChain);
+
+        verify(filterChain, times(1)).doFilter(req, res);
+        verifyNoInteractions(jwtProvider);
     }
 
     @Test
-    @DisplayName("shouldNotFilter()가 true를 반환하면 doFilterInternal은 호출되지 않는다")
-    void shouldNotFilter_true_means_doFilterIsBypassed() throws Exception {
+    @DisplayName("단일 * 패턴(/health/*)은 슬래시를 넘지 않는다: /health/ping은 우회, /health/ping/extra는 인증 대상")
+    void antSingleStar_doesNotCrossSlash() throws Exception {
+        // given: 별도 프로퍼티로 새 필터 생성
+        JwtFilterProperties pp = new JwtFilterProperties();
+        pp.setExcludePaths(List.of("/health/*")); // 단일 레벨만 우회
+        JwtAuthenticationFilter f = new JwtAuthenticationFilter(jwtProvider, pp.getExcludePaths());
+
+        // /health/ping  → 우회
+        MockHttpServletRequest req1 = new MockHttpServletRequest("GET", "/health/ping");
+        MockHttpServletResponse res1 = new MockHttpServletResponse();
+        f.doFilter(req1, res1, filterChain);
+        verify(filterChain, times(1)).doFilter(req1, res1);
+
+        // /health/ping/extra → 우회되지 않음(= 인증 대상) → Authorization 없으면 INVALID_HEADER 발생
+        MockHttpServletRequest req2 = new MockHttpServletRequest("GET", "/health/ping/extra");
+        MockHttpServletResponse res2 = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> f.doFilter(req2, res2, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    // CommonErrorCode에 있으면 ↓
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_HEADER);
+                    // UserErrorCode로 쓰신다면 ↓ 로 교체
+                    // assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.INVALID_HEADER);
+                });
+    }
+
+
+    @Test
+    @DisplayName("Bearer 뒤에 공백이 여러 개여도 → substring(7) 결과에 공백 포함 → 파싱 실패 시 INVALID_TOKEN")
+    void multipleSpacesAfterBearer_treatedAsInvalidToken() throws Exception {
+        String weirdHeader = "Bearer    token";
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", weirdHeader);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        // substring(7)은 "   token"이므로 파서가 예외 던지도록
+        when(jwtProvider.getUserId("   token")).thenThrow(new RuntimeException("bad"));
+
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                    // 또는 UserErrorCode.INVALID_TOKEN
+                });
+
+        verify(jwtProvider, times(1)).getUserId("   token");
+        verifyNoMoreInteractions(jwtProvider);
+        verifyNoInteractions(filterChain); // 실패 시 체인 호출 없음
+    }
+
+    @Test
+    @DisplayName("탭 문자 등 'Bearer '가 아니면 형식 오류 → INVALID_TOKEN")
+    void tabAfterBearer_isMalformed() {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer\tabc.def"); // 탭
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                });
+
+        verifyNoInteractions(jwtProvider);
+        verifyNoInteractions(filterChain);
+    }
+
+    @Test
+    @DisplayName("'Bearer'만 있고 공백/토큰이 없으면 형식 오류 → INVALID_TOKEN")
+    void onlyBearer_isMalformed() {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                });
+
+        verifyNoInteractions(jwtProvider);
+        verifyNoInteractions(filterChain);
+    }
+
+    // ─────────────────────────────────────
+    // 3) 체인 호출 횟수 보증
+    // ─────────────────────────────────────
+
+    @Test
+    @DisplayName("성공 경로에서는 체인이 정확히 1번 호출된다")
+    void chainCalledOnce_onSuccess() throws Exception {
+        String token = "ok.jwt";
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        when(jwtProvider.getUserId(token)).thenReturn(10L);
+        when(jwtProvider.getUserRole(token)).thenReturn("ADMIN");
+
+        filter.doFilter(req, res, filterChain);
+
+        verify(filterChain, times(1)).doFilter(req, res);
+        assertThat(req.getAttribute("X_USER_ID")).isEqualTo(10L);
+        assertThat(req.getAttribute("X_USER_ROLE")).isEqualTo(UserRole.ADMIN);
+    }
+
+
+    @Test
+    @DisplayName("예외 발생 시 체인은 호출되지 않는다(단락)")
+    void chainNotCalled_onException() {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class);
+
+        verifyNoInteractions(filterChain);
+    }
+
+    // ─────────────────────────────────────
+    // 4) exclude 경로는 헤더가 엉망이어도 그냥 우회(필터 미적용)
+    // ─────────────────────────────────────
+
+    @Test
+    @DisplayName("exclude 경로에서는 잘못된 Authorization이라도 예외 없이 통과한다")
+    void excludedPath_bypassesEvenWithBadHeader() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/public/bad");
+        req.addHeader("Authorization", "Bearer"); // 형식 불량이어도 우회
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, filterChain);
+
+        verify(filterChain, times(1)).doFilter(req, res);
+        verifyNoInteractions(jwtProvider);
+    }
+
+
+    @Test
+    @DisplayName("소문자 'bearer '는 허용되지 않음 → INVALID_TOKEN")
+    void lowercaseBearer_isMalformed() {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "bearer abc.def");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                });
+
+        verifyNoInteractions(jwtProvider);
+        verifyNoInteractions(filterChain);
+    }
+
+    @Test
+    @DisplayName("excludePaths에 매칭되면 필터링을 건너뛰고 그대로 체인 통과한다")
+    void bypass_whenExcludedPath() throws Exception {
         // given
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/public/test");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/public/test");
+        MockHttpServletResponse res = new MockHttpServletResponse();
 
         // when
-        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+        filter.doFilter(req, res, filterChain);
 
         // then
-        verify(filterChain, times(1)).doFilter(request, response); // 통과는 하지만 필터 내부 로직은 실행되지 않음
+        verify(filterChain, times(1)).doFilter(req, res);
+        // 내부에서 인증 시도/예외 없음
     }
 
     @Test
-    @DisplayName("유효한 토큰일 경우 사용자 ID 및 권한 정보를 Request에 설정한다")
-    void shouldFilter_andSetUserAttributes_whenValidToken()
-            throws ServletException, IOException, IOException {
+    @DisplayName("Authorization 헤더가 없으면 INVALID_HEADER로 BusinessException 발생")
+    void throw_whenMissingAuthorizationHeader() {
+        // given
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        // when / then
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    // CommonErrorCode에 정의돼 있다면 ↓
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_HEADER);
+                    // 만약 UserErrorCode를 쓰신다면 아래로 바꾸세요:
+                    // assertThat(be.getErrorCode()).isEqualTo(UserErrorCode.INVALID_HEADER);
+                });
+        verifyNoInteractions(jwtProvider);
+    }
+
+    @Test
+    @DisplayName("Authorization 형식이 'Bearer '로 시작하지 않으면 INVALID_TOKEN 발생")
+    void throw_whenMalformedAuthorizationHeader() {
+        // given
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Token abc.def.ghi"); // 잘못된 스킴
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        // when / then
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                    // 또는 UserErrorCode.INVALID_TOKEN (실제 선언 위치에 맞게)
+                });
+        verifyNoInteractions(jwtProvider);
+    }
+
+    @Test
+    @DisplayName("유효한 Bearer 토큰이면 사용자 속성을 설정하고 체인을 계속 진행한다")
+    void setAttributes_whenValidToken() throws Exception {
         // given
         String token = "valid.jwt.token";
         Long userId = 1L;
-        String userRole = "USER";
+        String role = "USER";
 
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
-        request.addHeader("Authorization", "Bearer " + token);
-
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
 
         when(jwtProvider.getUserId(token)).thenReturn(userId);
-        when(jwtProvider.getUserRole(token)).thenReturn(userRole);
+        when(jwtProvider.getUserRole(token)).thenReturn(role);
 
         // when
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+        filter.doFilter(req, res, filterChain);
 
         // then
-        assertThat(request.getAttribute("X_USER_ID")).isEqualTo(userId);
-        assertThat(request.getAttribute("X_USER_ROLE")).isEqualTo(UserRole.USER);
-
-        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(req.getAttribute("X_USER_ID")).isEqualTo(userId);
+        assertThat(req.getAttribute("X_USER_ROLE")).isEqualTo(UserRole.USER);
+        verify(filterChain, times(1)).doFilter(req, res);
     }
 
     @Test
-    @DisplayName("유효하지 않은 토큰일 경우 BusinessException 예외를 던진다")
-    void shouldThrowBusinessException_whenInvalidToken() {
+    @DisplayName("토큰 파싱 중 예외(RuntimeException 등)가 나면 INVALID_TOKEN으로 변환하여 던진다")
+    void wrapAnyParsingError_asInvalidToken() {
         // given
         String token = "invalid.token";
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
-        request.addHeader("Authorization", "Bearer " + token);
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
 
-        when(jwtProvider.getUserId(token)).thenThrow(new RuntimeException("유효하지 않은 토큰"));
+        when(jwtProvider.getUserId(token)).thenThrow(new RuntimeException("invalid"));
 
-        // then
-        assertThatThrownBy(
-                () -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
-                .isInstanceOf(BusinessException.class);
+        // when / then
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                });
     }
 
     @Test
-    @DisplayName("Authorization 헤더가 없으면 필터는 사용자 정보 없이 통과시킨다")
-    void shouldPassWithoutUserAttributes_whenNoAuthorizationHeader() throws Exception {
-        // given
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        // when
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        assertThat(request.getAttribute("X_USER_ID")).isNull();
-        assertThat(request.getAttribute("X_USER_ROLE")).isNull();
-        verify(filterChain).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 역할일 경우 BusinessException(INVALID_ROLE_VALUE)을 던진다")
-    void shouldThrowBusinessException_whenInvalidRole() {
+    @DisplayName("존재하지 않는 역할 문자열이면 INVALID_ROLE_BY_TOKEN 발생")
+    void throw_whenInvalidRoleValue() {
         // given
         String token = "valid.token.with.invalid.role";
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/secure");
-        request.addHeader("Authorization", "Bearer " + token);
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
 
         when(jwtProvider.getUserId(token)).thenReturn(1L);
         when(jwtProvider.getUserRole(token)).thenReturn("NOT_A_ROLE");
 
-        // when & then
-        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
-                .isInstanceOf(BusinessException.class);
+        // when / then
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_ROLE_BY_TOKEN);
+                });
+    }
+
+    @Test
+    @DisplayName("토큰은 Bearer지만 값이 비어 있거나 잘못되어도 INVALID_TOKEN으로 변환된다")
+    void emptyOrBadBearerToken_treatedAsInvalidToken() {
+        // given
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/secure");
+        req.addHeader("Authorization", "Bearer "); // 빈 토큰
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        // getUserId("") 호출 시 예외가 터지도록 설정(선택)
+        when(jwtProvider.getUserId("")).thenThrow(new RuntimeException("empty"));
+
+        // when / then
+        assertThatThrownBy(() -> filter.doFilter(req, res, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_TOKEN);
+                });
     }
 }


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

회원 식별 번호와 권한을 헤더로부터 더이상 받지 않도록 수정하고 토큰으로부터 정보를 가져오도록 합니다. 

## 🔍 관련 이슈
- Closes #32

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증 오류 코드 확장: 잘못된/누락된 Authorization 헤더, Bearer 형식 오류, 토큰 내 권한 오류를 구분해 반환.
- 변경 사항
  - JWT 인증 제외 경로 기본값을 /api/users/** → /api/v1/auth/**로 변경.
  - 공용·헬스 체크 경로의 인증 우회 동작을 더 일관되고 정확하게 처리.
- 버그 수정
  - 잘못된 Authorization 헤더/토큰 처리 시 일관된 에러 반환 및 필터 체인 미실행 보장.
- 설정
  - 인증 필터·인증 정보 리졸버에 대한 DEBUG 로그 레벨 설정 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->